### PR TITLE
Return GATT_SUCCESS when Descriptor is read

### DIFF
--- a/app/src/main/java/com/example/androidthings/gattserver/GattServerActivity.java
+++ b/app/src/main/java/com/example/androidthings/gattserver/GattServerActivity.java
@@ -360,7 +360,7 @@ public class GattServerActivity extends Activity {
                 }
                 mBluetoothGattServer.sendResponse(device,
                         requestId,
-                        BluetoothGatt.GATT_FAILURE,
+                        BluetoothGatt.GATT_SUCCESS,
                         0,
                         returnValue);
             } else {


### PR DESCRIPTION
Existing code was returning GATT_FAILURE for all code paths in onDescriptorReadRequest - if the config descriptor matches and is valid, GATT_SUCCESS should be returned along with the correct value for ENABLE/DISABLE notification